### PR TITLE
feat(tiling): add acceptable layered window whitelist

### DIFF
--- a/yatta/src/main.rs
+++ b/yatta/src/main.rs
@@ -48,6 +48,7 @@ lazy_static! {
     static ref DESKTOP_EXES: Arc<Mutex<HashMap<String, usize>>> =
         Arc::new(Mutex::new(HashMap::new()));
     static ref LAST_LAYOUT: Arc<Mutex<Layout>> = Arc::new(Mutex::new(Layout::BSPV));
+    static ref LAYERED_EXE_WHITELIST: Vec<String> = vec!["steam.exe".to_string()];
 }
 
 #[derive(Clone, Debug)]

--- a/yatta/src/window.rs
+++ b/yatta/src/window.rs
@@ -41,7 +41,14 @@ use bindings::Windows::Win32::{
     },
 };
 
-use crate::{rect::Rect, windows_event::WindowsEventType, FLOAT_CLASSES, FLOAT_EXES, FLOAT_TITLES};
+use crate::{
+    rect::Rect,
+    windows_event::WindowsEventType,
+    FLOAT_CLASSES,
+    FLOAT_EXES,
+    FLOAT_TITLES,
+    LAYERED_EXE_WHITELIST,
+};
 
 bitflags! {
     #[derive(Default)]
@@ -276,8 +283,12 @@ impl Window {
     }
 
     pub fn should_manage(&self, event: Option<WindowsEventType>) -> bool {
+        match self.title() {
+            None => return false,
+            Some(_) => {}
+        }
+
         let is_cloaked = self.is_cloaked();
-        let has_title = self.title().is_some();
         let styles = self.get_style();
         let extended_styles = self.get_ex_style();
 
@@ -288,18 +299,26 @@ impl Window {
             }
         }
 
-        if has_title && if allow_cloaked { true } else { !is_cloaked } {
-            match (styles, extended_styles) {
-                (Ok(style), Ok(ex_style)) => {
-                    if style.contains(GwlStyle::CAPTION)
-                        && ex_style.contains(GwlExStyle::WINDOWEDGE)
-                        && !ex_style.contains(GwlExStyle::DLGMODALFRAME)
-                        // Get a lot of dupe events coming through that make the redrawing go crazy 
-                        // on FocusChange events if I don't filter out this one 
-                        && !ex_style.contains(GwlExStyle::LAYERED)
-                    {
-                        if let Some(title) = self.title() {
-                            if let Ok(path) = self.exe_path() {
+        match (allow_cloaked, is_cloaked) {
+            // if allowing cloaked windows, we don't need to check the cloaked status
+            (true, _) |
+            // if not allowing cloaked windows, we need to ensure the window is not cloaked
+            (false, false) => {
+                match (styles, extended_styles) {
+                    (Ok(style), Ok(ex_style)) => {
+                        if let (Some(title), Ok(path)) = (self.title(), self.exe_path()) {
+                            let exe_name = exe_name_from_path(&path);
+                            let allow_layered = LAYERED_EXE_WHITELIST.contains(&exe_name);
+
+                            if style.contains(GwlStyle::CAPTION)
+                                && ex_style.contains(GwlExStyle::WINDOWEDGE)
+                                && !ex_style.contains(GwlExStyle::DLGMODALFRAME)
+                                // Get a lot of dupe events coming through that make the redrawing go crazy
+                                // on FocusChange events if I don't filter out this one. But, if we are
+                                // allowing a specific layered window on the whitelist (like Steam), it should
+                                // pass this check
+                                && (allow_layered || !ex_style.contains(GwlExStyle::LAYERED))
+                            {
                                 debug!(
                                     "managing {} - {} (styles: {:?}) (extended styles: {:?})",
                                     exe_name_from_path(&path),
@@ -307,14 +326,10 @@ impl Window {
                                     style,
                                     ex_style
                                 );
-                            }
-                        }
 
-                        true
-                    } else {
-                        if let Some(event) = event {
-                            if let Some(title) = self.title() {
-                                if let Ok(path) = self.exe_path() {
+                                true
+                            } else {
+                                if let Some(event) = event {
                                     debug!(
                                         "ignoring {} - {} (event: {}) (cloaked: {}) (styles: {:?}) (extended styles: {:?})",
                                         exe_name_from_path(&path),
@@ -325,15 +340,16 @@ impl Window {
                                         ex_style
                                     );
                                 }
+                                false
                             }
+                        } else {
+                            false
                         }
-                        false
                     }
+                    _ => false,
                 }
-                _ => false,
             }
-        } else {
-            false
+            _ => false,
         }
     }
 


### PR DESCRIPTION
As highlighted in #19, certain applications such as Steam may have `GwlExStyle::LAYERED` set when events are emitted by the window being closed by the user.

This commit introduces a global whitelist that is checked when evaluating whether or not yatta should try to handle an emitted event in `Window::should_manage()`.

Some general refactoring of the logic in that fn to add some early returns, and some comments describing the boolean cases that we are trying to match on for the desired behaviours.

fixes #19